### PR TITLE
Fix application of electron ID

### DIFF
--- a/DiMuons/crab/make_crab_script_AWB.py
+++ b/DiMuons/crab/make_crab_script_AWB.py
@@ -102,6 +102,9 @@ for samp in samps:
             else:
                 line = line.replace('= NUM', '= 5')
 
+        if 'outLFNDirBase' in line:
+            line = line.replace('STR', '%s%s' % (time.strftime('%Y_%m_%d'), test_str))
+
         # if 'inputDBS' in line:
         #     line = line.replace("= 'DBS'", "= '%s'"  % samp.inputDBS)
 

--- a/DiMuons/crab/templates/EDAnalyzer17_94X.py
+++ b/DiMuons/crab/templates/EDAnalyzer17_94X.py
@@ -48,8 +48,8 @@ readFiles = cms.untracked.vstring();
 readFiles.extend(samp.files);
 
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.source = cms.Source('PoolSource',fileNames = readFiles)
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
 process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()
@@ -72,14 +72,17 @@ process.TFileService = cms.Service('TFileService', fileName = cms.string('tuple.
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 
-## Modeled after https://github.com/GhentAnalysis/heavyNeutrino/blob/master/multilep/python/egmSequence_cff.py
-## Have to merge V2 electron IDs using this recipe: https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_formats
-from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
-eleIDs = [ 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
-           'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff' ]
-for eleID in eleIDs: setupAllVIDIdsInModule(process, eleID, setupVIDElectronSelection)
+
+setupEgammaPostRecoSeq( process,
+                        runVID = True ,  ## Needed for 2017 V2 IDs
+                        era    = '2017-Nov17ReReco' )
+                        # eleIDModules = [ 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
+                        #                  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff' ] )
 
 
 # /////////////////////////////////////////////////////////////
@@ -120,7 +123,7 @@ print 'About to run the process path'
 ## https://github.com/pfs/TopLJets2015/blob/master/TopAnalysis/python/customizeJetTools_cff.py#L47
 ## https://github.com/pfs/TopLJets2015/blob/master/TopAnalysis/python/customizeEGM_cff.py#L67
 
-process.egamma_step = cms.Path( process.egmGsfElectronIDSequence )  ## See eleIDs above
+process.egamma_step = cms.Path( process.egammaPostRecoSeq )  ## See setupEgammaPostRecoSeq above
 process.ntuple_step = cms.Path( process.dimuons )
 
 process.schedule = cms.Schedule( process.egamma_step, process.ntuple_step )  ## , process.treeOut_step )

--- a/DiMuons/crab/templates/crab_config_AWB.py
+++ b/DiMuons/crab/templates/crab_config_AWB.py
@@ -23,8 +23,8 @@ config.Data.useParent = False
 config.Data.splitting = 'STR'
 config.Data.unitsPerJob = NUM  ## Should take ~10 minutes for 100k events
 
-config.Data.outLFNDirBase = '/store/group/phys_higgs/HiggsExo/H2Mu/UF/ntuples/2017/94X_v2/'
-# config.Data.outLFNDirBase = '/store/user/abrinke1/HiggsToMuMu/ntuples/2016/94X_v2/3l/'
+config.Data.outLFNDirBase = '/store/group/phys_higgs/HiggsExo/H2Mu/UF/ntuples/2017/94X_v2/STR/'
+# config.Data.outLFNDirBase = '/store/user/abrinke1/HiggsToMuMu/ntuples/2016/94X_v2/3l/STR/'
 config.Data.publication = False
 config.Data.outputDatasetTag = 'STR'
 

--- a/DiMuons/interface/EleHelper.h
+++ b/DiMuons/interface/EleHelper.h
@@ -9,7 +9,7 @@
 void FillEleInfos( EleInfos& _eleInfos,
 		   const pat::ElectronCollection elesSelected,
 		   const reco::Vertex primaryVertex, const edm::Event& iEvent,
-		   const std::vector<std::array<bool, 4>> ele_ID_pass, const double ele_mva_val,
+		   const std::vector<std::array<bool, 4>> ele_ID_pass,
 		   LepMVAVars & _lepVars_ele, std::shared_ptr<TMVA::Reader> & _lepMVA_ele,
 		   const double _rho, const edm::Handle<pat::JetCollection>& jets,
 		   const edm::Handle<pat::PackedCandidateCollection> pfCands,
@@ -21,7 +21,7 @@ pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>&
 				    const edm::Handle< edm::ValueMap<bool> >& ele_id_medium, const edm::Handle< edm::ValueMap<bool> >& ele_id_tight,
 				    const edm::Handle< edm::ValueMap<float> >& ele_id_mva, const std::string _ele_ID,
 				    const double _ele_pT_min, const double _ele_eta_max,
-				    std::vector<std::array<bool, 4>>& ele_ID_pass, double & ele_mva_val);
+				    std::vector<std::array<bool, 4>>& ele_ID_pass );
 
 bool   ElePassKinematics( const pat::Electron ele, const reco::Vertex primaryVertex );
 double EleCalcRelIsoPF  ( const pat::Electron ele, const double rho, EffectiveAreas eleEffArea, const std::string type );

--- a/DiMuons/interface/EleHelper.h
+++ b/DiMuons/interface/EleHelper.h
@@ -9,7 +9,7 @@
 void FillEleInfos( EleInfos& _eleInfos,
 		   const pat::ElectronCollection elesSelected,
 		   const reco::Vertex primaryVertex, const edm::Event& iEvent,
-		   const std::vector<std::array<bool, 4>> ele_ID_pass,
+		   const std::array<std::string, 5> ele_ID_names,
 		   LepMVAVars & _lepVars_ele, std::shared_ptr<TMVA::Reader> & _lepMVA_ele,
 		   const double _rho, const edm::Handle<pat::JetCollection>& jets,
 		   const edm::Handle<pat::PackedCandidateCollection> pfCands,
@@ -17,11 +17,8 @@ void FillEleInfos( EleInfos& _eleInfos,
 
 
 pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>& eles, const reco::Vertex primaryVertex,
-				    const edm::Handle< edm::ValueMap<bool> >& ele_id_veto, const edm::Handle< edm::ValueMap<bool> >& ele_id_loose,
-				    const edm::Handle< edm::ValueMap<bool> >& ele_id_medium, const edm::Handle< edm::ValueMap<bool> >& ele_id_tight,
-				    const edm::Handle< edm::ValueMap<float> >& ele_id_mva, const std::string _ele_ID,
-				    const double _ele_pT_min, const double _ele_eta_max,
-				    std::vector<std::array<bool, 4>>& ele_ID_pass );
+				    const std::array<std::string, 5> ele_ID_names, const std::string _ele_ID,
+				    const double _ele_pT_min, const double _ele_eta_max );
 
 bool   ElePassKinematics( const pat::Electron ele, const reco::Vertex primaryVertex );
 double EleCalcRelIsoPF  ( const pat::Electron ele, const double rho, EffectiveAreas eleEffArea, const std::string type );

--- a/DiMuons/plugins/UFDiMuonsAnalyzer.cc
+++ b/DiMuons/plugins/UFDiMuonsAnalyzer.cc
@@ -483,7 +483,7 @@ void UFDiMuonsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   double ele_mva_val;
   pat::ElectronCollection elesSelected = SelectEles( eles, primaryVertex, ele_id_veto, ele_id_loose,
 						     ele_id_medium, ele_id_tight, ele_id_mva, _ele_ID,
-						     _ele_pT_min, _ele_eta_max, ele_ID_pass, ele_mva_val );
+						     _ele_pT_min, _ele_eta_max, ele_ID_pass );
   
   // Sort the selected electrons by pT
   sort(elesSelected.begin(), elesSelected.end(), sortElesByPt);
@@ -492,7 +492,7 @@ void UFDiMuonsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   if ( ( muonsSelected.size() + elesSelected.size() ) < (unsigned int) _skim_nLeptons )
     return;
 
-  FillEleInfos( _eleInfos, elesSelected, primaryVertex, iEvent, ele_ID_pass, ele_mva_val,
+  FillEleInfos( _eleInfos, elesSelected, primaryVertex, iEvent, ele_ID_pass,
 		_lepVars_ele, _lepMVA_ele, _rho, jets, pfCands, eleEffArea );
   _nEles = _eleInfos.size();
 

--- a/DiMuons/plugins/UFDiMuonsAnalyzer.h
+++ b/DiMuons/plugins/UFDiMuonsAnalyzer.h
@@ -366,11 +366,11 @@ private:
 
   // Electrons
   edm::EDGetTokenT<edm::View<pat::Electron>> _eleCollToken;
-  edm::EDGetTokenT< edm::ValueMap<bool> >    _eleIdVetoToken;
-  edm::EDGetTokenT< edm::ValueMap<bool> >    _eleIdLooseToken;
-  edm::EDGetTokenT< edm::ValueMap<bool> >    _eleIdMediumToken;
-  edm::EDGetTokenT< edm::ValueMap<bool> >    _eleIdTightToken;
-  edm::EDGetTokenT< edm::ValueMap<float> >   _eleIdMvaToken;
+ std::string _eleIdVetoName;
+ std::string _eleIdLooseName;
+ std::string _eleIdMediumName;
+ std::string _eleIdTightName;
+ std::string _eleIdMvaName;
 
   // Taus
   edm::EDGetTokenT<pat::TauCollection> _tauCollToken;

--- a/DiMuons/python/Analyzer_2017_94X_MC_cff.py
+++ b/DiMuons/python/Analyzer_2017_94X_MC_cff.py
@@ -39,11 +39,11 @@ dimuons = cms.EDAnalyzer('UFDiMuonsAnalyzer',
 
                          ## Electrons
                          eleColl     = cms.InputTag("slimmedElectrons"),
-                         eleIdVeto   = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto"),
-                         eleIdLoose  = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose"),
-                         eleIdMedium = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium"),
-                         eleIdTight  = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight"),
-                         eleIdMva    = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values"),
+                         eleIdVeto   = cms.string("cutBasedElectronID-Fall17-94X-V2-veto"),
+                         eleIdLoose  = cms.string("cutBasedElectronID-Fall17-94X-V2-loose"),
+                         eleIdMedium = cms.string("cutBasedElectronID-Fall17-94X-V2-medium"),
+                         eleIdTight  = cms.string("cutBasedElectronID-Fall17-94X-V2-tight"),
+                         eleIdMva    = cms.string("ElectronMVAEstimatorRun2Fall17NoIsoV1Values"),
                          ## https://github.com/GhentAnalysis/heavyNeutrino/blob/master/multilep/test/multilep.py#L107
                          eleEffArea  = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt'),
 

--- a/DiMuons/python/Analyzer_2017_94X_cff.py
+++ b/DiMuons/python/Analyzer_2017_94X_cff.py
@@ -39,11 +39,11 @@ dimuons = cms.EDAnalyzer('UFDiMuonsAnalyzer',
 
                          ## Electrons
                          eleColl     = cms.InputTag("slimmedElectrons"),
-                         eleIdVeto   = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto"),
-                         eleIdLoose  = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose"),
-                         eleIdMedium = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium"),
-                         eleIdTight  = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight"),
-                         eleIdMva    = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values"),
+                         eleIdVeto   = cms.string("cutBasedElectronID-Fall17-94X-V2-veto"),
+                         eleIdLoose  = cms.string("cutBasedElectronID-Fall17-94X-V2-loose"),
+                         eleIdMedium = cms.string("cutBasedElectronID-Fall17-94X-V2-medium"),
+                         eleIdTight  = cms.string("cutBasedElectronID-Fall17-94X-V2-tight"),
+                         eleIdMva    = cms.string("ElectronMVAEstimatorRun2Fall17NoIsoV1Values"),
                          ## https://github.com/GhentAnalysis/heavyNeutrino/blob/master/multilep/test/multilep.py#L107
                          eleEffArea  = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt'),
 

--- a/DiMuons/python/Samples_2017_94X_v2.py
+++ b/DiMuons/python/Samples_2017_94X_v2.py
@@ -147,31 +147,31 @@ H2Mu_gg_dir  = 'GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/PU2017_12Apr2018_9
 H2Mu_ttH_dir = 'ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/'
 
 ## Gluon-gluon fusion, amc@NLO
-H2Mu_gg_120_NLO = sample( name  = 'H2Mu_gg_120',
-                          DAS   = '/GluGluHToMuMu_M120_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-                          nEvt  = 1900000 ) ## 1.9 million
+H2Mu_gg_120_NLO = sample( name = 'H2Mu_gg_120',
+                          DAS  = '/GluGluHToMuMu_M120_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                          nEvt = 1900000 ) ## 1.9 million
 
 H2Mu_gg_125_NLO = sample( name  = 'H2Mu_gg',
                           DAS   = '/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
                           nEvt  = 2000000, ## 2.0 million
                           files = [ AWB_dir+H2Mu_gg_dir+'226E7A92-6D42-E811-B5E3-44A8423D7E31.root' ] )
 
-H2Mu_gg_130_NLO = sample( name  = 'H2Mu_gg_130',
-                          DAS   = '/GluGluHToMuMu_M130_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-                          nEvt  = 1700000 ) ## 1.7 million
+H2Mu_gg_130_NLO = sample( name = 'H2Mu_gg_130',
+                          DAS  = '/GluGluHToMuMu_M130_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                          nEvt = 1700000 ) ## 1.7 million
 
-# ## Vector boson fusion
-# H2Mu_VBF = sample( name = 'H2Mu_VBF',
-#                    DAS  = '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-#                    nEvt = 249200 ) ## 250 k
+## Vector boson fusion
+H2Mu_VBF_120_NLO = sample( name = 'H2Mu_VBF_120',
+                           DAS  = '/VBFHToMuMu_M120_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                           nEvt = 1000000 ) ## 1.0 million
 
-# H2Mu_VBF_120 = sample( name = 'H2Mu_VBF_120',
-#                        DAS  = '/VBF_HToMuMu_M120_13TeV_powheg_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-#                        nEvt = 249200 ) ## 250 k
+H2Mu_VBF_125_NLO = sample( name = 'H2Mu_VBF',
+                           DAS  = '/VBFHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                           nEvt = 1000000 ) ## 1.0 million
 
-# H2Mu_VBF_130 = sample( name = 'H2Mu_VBF_130',
-#                        DAS  = '/VBF_HToMuMu_M130_13TeV_powheg_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-#                        nEvt = 249200 ) ## 250 k
+H2Mu_VBF_130_NLO = sample( name = 'H2Mu_VBF_130',
+                           DAS  = '/VBFHToMuMu_M130_13TeV_amcatnloFXFX_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                           nEvt = 965810 ) ## 1.0 million
 
 ## WH (+)
 H2Mu_WH_pos_120 = sample( name = 'H2Mu_WH_pos_120',
@@ -229,20 +229,20 @@ H2Mu_ttH_130 = sample( name = 'H2Mu_ttH_130',
 
 Signal = []  ## All H2Mu signal samples
 Signal.append(H2Mu_gg_125_NLO)
-# Signal.append(H2Mu_VBF_125)
+Signal.append(H2Mu_VBF_125_NLO)
 Signal.append(H2Mu_WH_pos_125)
 Signal.append(H2Mu_WH_neg_125)
 Signal.append(H2Mu_ZH_125)
 Signal.append(H2Mu_ttH_125)
 
 Signal.append(H2Mu_gg_120_NLO)
-# Signal.append(H2Mu_VBF_120)
+Signal.append(H2Mu_VBF_120_NLO)
 Signal.append(H2Mu_WH_pos_120)
 # Signal.append(H2Mu_WH_neg_120)
 Signal.append(H2Mu_ZH_120)
 
 Signal.append(H2Mu_gg_130_NLO)
-# Signal.append(H2Mu_VBF_130)
+Signal.append(H2Mu_VBF_130_NLO)
 Signal.append(H2Mu_WH_pos_130)
 Signal.append(H2Mu_WH_neg_130)
 Signal.append(H2Mu_ZH_130)
@@ -266,11 +266,6 @@ ZJets_AMC = sample( name = 'ZJets_AMC',
                     DAS  = '/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/'+DAS_era_MC_b+'_ext1-v1/MINIAODSIM',
                     nEvt = 182217609)  ## 182 million
 
-# # ZJets_hiM = sample( name = 'ZJets_hiM',
-# #                     DAS  = '/DYJetsToLL_M-100to200_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/'+DAS_era_MC+'_ext1-v1/MINIAODSIM',
-# #                     nEvt = 1083606 ) ## 1.1 million
-# #                     ## GT   = 'Spring16_23Sep2016V2_MC' ) ## Need a different global tag? - AWB 19.01.17
-
 ZJets_MG_1 = sample( name = 'ZJets_MG_1',
                      DAS  = '/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/'+DAS_era_MC_c+'-v1/MINIAODSIM',
                      nEvt = 48675378 ) ## 49 million
@@ -279,10 +274,45 @@ ZJets_MG_2 = sample( name = 'ZJets_MG_2',
                      DAS  = '/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/'+DAS_era_MC_c+'_ext1-v1/MINIAODSIM',
                      nEvt = 49125561 ) ## 49 million
 
+# ZJets_hiM_AMC = sample( name = 'ZJets_hiM_AMC',
+#                         DAS  = '/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2*/MINIAODSIM',
+#                         nEvt =  )  ## 60 million
+
+# ZJets_hiM_MG = sample( name = 'ZJets_hiM_MG',
+#                        DAS  = '/DYJetsToLL_M-105To160_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2*/MINIAODSIM',
+#                        nEvt =  )  ## ? million
+
+
 Background.append(ZJets_AMC)
-# # Background.append(ZJets_hiM)
 Background.append(ZJets_MG_1)
 Background.append(ZJets_MG_2)
+# Background.append(ZJets_hiM_AMC)
+# Background.append(ZJets_hiM_MG)
+
+###############
+###  ttbar  ###
+###############
+
+tt_ll_MG = sample( name = 'tt_ll_MG',
+                   DAS  = '/TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                   nEvt = 28380110 ) ## 28 million
+
+tt_ll_POW = sample( name = 'tt_ll_POW',
+                    DAS  = '/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_b+'-v2/MINIAODSIM',
+                    nEvt = 69155808 ) ## 69 million
+
+tt_ljj_POW_1 = sample ( name = 'tt_ljj_POW_1',
+                        DAS  = '/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                        nEvt = 111325048 ) ## 111 million
+
+tt_ljj_POW_2 = sample ( name = 'tt_ljj_POW_2',
+                        DAS  = '/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_a+'-v2/MINIAODSIM',
+                        nEvt = 110085096 ) ## 110 million
+
+Background.append(tt_ll_MG)
+Background.append(tt_ll_POW)
+Background.append(tt_ljj_POW_1)
+Background.append(tt_ljj_POW_2)
 
 ####################
 ###  Single top  ###
@@ -299,158 +329,128 @@ tW_neg = sample( name = 'tW_neg',
 Background.append(tW_pos)
 Background.append(tW_neg)
 
-###############
-###  ttbar  ###
-###############
+#################
+###  Diboson  ###
+#################
 
-tt_ll_MG = sample( name = 'tt_ll_MG',
-                   DAS  = '/TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-                   nEvt = 28380110 ) ## 6 million
+WW_2l_1 = sample( name = 'WW_2l_1',
+             DAS  = '/WWTo2L2Nu_NNPDF31_TuneCP5_13TeV-powheg-pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+             nEvt = 2000000 ) ## 2 million
 
-tt_ll_POW = sample( name = 'tt_ll_POW',
-                    DAS  = '/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_b+'-v2/MINIAODSIM',
-                    nEvt = 69155808 ) ## 69 million
+WW_2l_2 = sample( name = 'WW_2l_2',
+               DAS = '/WWTo2L2Nu_NNPDF31_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_a+'_ext1-v1/MINIAODSIM',
+             nEvt = 2000000 ) ## 2 million
 
-tt_ljj_POW_1 = sample ( name = 'tt_ljj_POW_1',
-                        DAS  = '/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
-                        nEvt = 111325048 ) ## 111 million
-
-tt_ljj_POW_2 = sample ( name = 'tt_ljj_POW_2',
-                        DAS  = '/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/'+DAS_era_MC_a+'-v2/MINIAODSIM',
-                        nEvt = 110085096 ) ## 110 million
-
-Background.append(tt_ll_MG)
-Background.append(tt_ll_POW)
-# Background.append(tt_ljj_POW_1)
-# Background.append(tt_ljj_POW_2)
-
-# #################
-# ###  Diboson  ###
-# #################
-
-# WW = sample( name = 'WW',
-#              DAS  = '/WWTo2L2Nu_13TeV-powheg/'+DAS_era_MC+'-v1/MINIAODSIM',
-#              nEvt = 1999000 ) ## 2 million
-
-# WW_HER = sample( name = 'WW_HER',
-#                  DAS  = '/WWTo2L2Nu_13TeV-powheg-herwigpp/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                  nEvt = 1982372 ) ## 2 million
-
-# WW_up = sample( name = 'WW_up',
-#                 DAS  = '/WWTo2L2Nu_13TeV-powheg-CUETP8M1Up/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                 nEvt =  1984000 ) ## 2 million
-
-# WW_down = sample( name = 'WW_down',
-#                   DAS  = '/WWTo2L2Nu_13TeV-powheg-CUETP8M1Down/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                   nEvt = 1988000 ) ## 2 million
-
-# WZ_2l = sample( name = 'WZ_2l',
-#                 DAS  = '/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                 nEvt =  26517272 ) ## 27 million
+WZ_2l = sample( name = 'WZ_2l',
+                DAS  = '/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM',
+                nEvt =  27582164 ) ## 28 million
 
 WZ_3l = sample( name = 'WZ_3l',
                 DAS  = '/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/'+DAS_era_MC_b+'-v1/MINIAODSIM',
                 nEvt = 10987679 ) ## 11 million
 
-# ZZ_2l_2v = sample( name = 'ZZ_2l_2v',
-#                    DAS  = '/ZZTo2L2Nu_13TeV_powheg_pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                    nEvt = 8842475 ) ## 9 million
-
-# ZZ_2l_2q = sample( name = 'ZZ_2l_2q',
-#                    DAS  = '/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                    nEvt = 15345572 ) ## 15 million
+ZZ_2l_2q = sample( name = 'ZZ_2l_2q',
+                   DAS  = '//ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/'+DAS_era_MC_a+'-v1/MINIAODSIM/',
+                   nEvt = 27840918 ) ## 28 million
 
 ZZ_4l = sample( name = 'ZZ_4l',
                 DAS  = '/ZZTo4L_13TeV_powheg_pythia8/'+DAS_era_MC_a+'_ext1-v1/MINIAODSIM',
                 nEvt = 98091559 ) ## 98 million
 
-# Background.append(WW)
-# # Background.append(WW_HER)
-# # Background.append(WW_up)
-# # Background.append(WW_down)
-# Background.append(WZ_2l)
+Background.append(WW_2l_1)
+Background.append(WW_2l_2)
+Background.append(WZ_2l)
 Background.append(WZ_3l)
-# Background.append(ZZ_2l_2v)
-# Background.append(ZZ_2l_2q)
-# Background.append(ZZ_4l_AMC)
+Background.append(ZZ_2l_2q)
 Background.append(ZZ_4l)
 
-# # #################
-# # ###  Triboson  ##
-# # #################
+################
+###  ttbar+X  ##
+################
 
-# # WWW = sample( name = 'WWW',
-# #               DAS  = '/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-# #               nEvt = 240000 ) ## 240 k
+ttW = sample( name = 'ttW',
+              DAS  = '/TTWJetsToLNu_TuneCP5_PSweights_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 4908905 ) ## 4.9 million
 
-# # WWZ = sample( name = 'WWZ',
-# #               DAS  = '/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-# #               nEvt = 250000 ) ## 250 k
 
-# # WZZ = sample( name = 'WZZ',
-# #               DAS  = '/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-# #               nEvt = 246800 ) ## 250 k
+ttZ = sample( name = 'ttZ',
+              DAS  = '/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 7563490 ) ## 7.5 million
 
-# # ZZZ = sample( name = 'ZZZ',
-# #               DAS  = '/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-# #               nEvt = 249237 ) ## 250 k
+ttZ_lowM = sample( name = 'ttZ_lowM',
+                   DAS  = '/TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+                   nEvt = 250000 ) ## 250 k
+ttH = sample( name = 'ttH',
+              DAS  = '/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 9779592 ) ## 10 million
 
-# # Background.append(WWW)
-# # Background.append(WWZ)
-# # Background.append(WZZ)
-# # Background.append(ZZZ)
+ttWW = sample( name = 'ttWW',
+               DAS  = '/TTWW_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM',
+               nEvt = 200000 ) ## 200 k
+
+Background.append(ttW)
+Background.append(ttZ)
+Background.append(ttZ_lowM)
+Background.append(ttH)
+Background.append(ttWW)
 
 # #####################
 # ###  Single top+X  ##
 # #####################
 
-# # tZq = sample( name = 'tZq',
-# #               DAS  = '/tZq_ll_4f_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'_ext1-v1/MINIAODSIM',
-# #               nEvt = 14509520 ) ## 15 million
+tZq = sample( name = 'tZq',
+              DAS  = '/tZq_ll_4f_ckm_NLO_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM',
+              nEvt = 13276146 ) ## 13 million
 
-# tZq_HER = sample( name = 'tZq_HER',
-#                   DAS  = '/tZq_ll_4f_13TeV-amcatnlo-herwigpp/'+DAS_era_MC+'-v1/MINIAODSIM',
-#                   nEvt = 9999044 ) ## 10 million
+# tZW = sample( name = 'tZW',
+#               DAS  = '/ST_tWll_5f_LO_TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2*/MINIAODSIM',
+#               nEvt =  ) ## 
 
-# # tZW = sample( name = 'tZW',
-# #               DAS  = '/ST_tWll_5f_LO_13TeV-MadGraph-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-# #               nEvt = 50000 ) ## 50 k
+tHq = sample( name = 'tHq',
+              DAS  = '/THQ_4f_Hincl_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 3381548 ) ## 3 million
 
-# # Background.append(tZq)
-# Background.append(tZq_HER)
-# # Background.append(tZW)
+tHW = sample( name = 'tHW',
+              DAS  = '/THW_5f_Hincl_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 1439996 ) ## 1 million
 
-# ################
-# ###  ttbar+X  ##
-# ################
+Background.append(tZq)
+# Background.append(tZW)
+Background.append(tHq)
+Background.append(tHW)
 
-# ttW_1 = sample( name = 'ttW_1',
-#                 DAS  = '/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/'+DAS_era_MC+'_ext1-v3/MINIAODSIM',
-#                 nEvt = 2160168 ) ## 2 million
+#################
+###  Triboson  ##
+#################
 
-# ttW_2 = sample( name = 'ttW_2',
-#                 DAS  = '/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/'+DAS_era_MC+'_ext2-v1/MINIAODSIM',
-#                 nEvt = 3120397 ) ## 3 million
+WWW = sample( name = 'WWW',
+              DAS  = '/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM',
+              nEvt = 232300 ) ## 230 k
 
-# ttZ = sample( name = 'ttZ',
-#               DAS  = '/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/'+DAS_era_MC+'_ext1-v1/MINIAODSIM',
-#               nEvt = 1992438 ) ## 2 million
+WWZ = sample( name = 'WWZ',
+              DAS  = '/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM',
+              nEvt = 250000 ) ## 250 k
 
-# ttH = sample( name = 'ttH',
-#               DAS  = '/ttHToNonbb_M125_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/'+DAS_era_MC+'-v1/MINIAODSIM',
-#               nEvt = 3981250 ) ## 4 million
+WZZ = sample( name = 'WZZ',
+              DAS  = '/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM',
+              nEvt = 250000 ) ## 250 k
 
-# Background.append(ttW_1)
-# Background.append(ttW_2)
-# Background.append(ttZ)
-# Background.append(ttH)
+ZZZ = sample( name = 'ZZZ',
+              DAS  = '/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM',
+              nEvt = 250000 ) ## 250 k
+
+Background.append(WWW)
+Background.append(WWZ)
+Background.append(WZZ)
+Background.append(ZZZ)
 
 
-# DataAndMC = []
-# DataAndMC.extend(SingleMu)
-# DataAndMC.extend(Signal)
-# DataAndMC.extend(Background)
+DataAndMC = []
+DataAndMC.extend(SingleMu)
+# DataAndMC.extend(DoubleMu)
+DataAndMC.extend(Signal)
+DataAndMC.extend(Background)
 
-# MC = []
-# MC.extend(Signal)
-# MC.extend(Background)
+MC = []
+MC.extend(Signal)
+MC.extend(Background)

--- a/DiMuons/src/EleHelper.cc
+++ b/DiMuons/src/EleHelper.cc
@@ -4,7 +4,7 @@
 void FillEleInfos( EleInfos& _eleInfos, 
 		   const pat::ElectronCollection elesSelected,
 		   const reco::Vertex primaryVertex, const edm::Event& iEvent,
-		   const std::vector<std::array<bool, 4>> ele_ID_pass, const double ele_mva_val,
+		   const std::vector<std::array<bool, 4>> ele_ID_pass,
 		   LepMVAVars & _lepVars_ele, std::shared_ptr<TMVA::Reader> & _lepMVA_ele,
                    const double _rho, const edm::Handle<pat::JetCollection>& jets,
                    const edm::Handle<pat::PackedCandidateCollection> pfCands,
@@ -32,7 +32,7 @@ void FillEleInfos( EleInfos& _eleInfos,
     _eleInfo.isTightID  = ele_ID_pass.at(i)[3];
 
     // EGamma POG MVA quality
-    _eleInfo.mvaID = ele_mva_val;
+    _eleInfo.mvaID = ele.userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV1Values");
 
     // Basic isolation
     _eleInfo.relIso         = EleCalcRelIsoPF( ele, _rho, eleEffArea, "DeltaBeta" );
@@ -95,7 +95,7 @@ pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>&
 				    const edm::Handle< edm::ValueMap<bool> >& ele_id_medium, const edm::Handle< edm::ValueMap<bool> >& ele_id_tight,
 				    const edm::Handle< edm::ValueMap<float> >& ele_id_mva, const std::string _ele_ID,
 				    const double _ele_pT_min, const double _ele_eta_max,
-				    std::vector<std::array<bool, 4>>& ele_ID_pass, double & ele_mva_val ) {
+				    std::vector<std::array<bool, 4>>& ele_ID_pass ) {
   
   // Main Egamma POG page: https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPOG
   // Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaIDRecipesRun2
@@ -127,11 +127,10 @@ pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>&
     if ( ele->pt()          < _ele_pT_min  ) continue;
     if ( fabs( ele->eta() ) > _ele_eta_max ) continue;
 
-    bool _isVeto   = (*ele_id_veto  )[ele] && ElePassKinematics(*ele, primaryVertex);
-    bool _isLoose  = (*ele_id_loose )[ele] && ElePassKinematics(*ele, primaryVertex);
-    bool _isMedium = (*ele_id_medium)[ele] && ElePassKinematics(*ele, primaryVertex);
-    bool _isTight  = (*ele_id_tight )[ele] && ElePassKinematics(*ele, primaryVertex);
-    ele_mva_val    = (*ele_id_mva   )[ele];
+    bool _isVeto   = ele->electronID("cutBasedElectronID-Fall17-94X-V2-veto");
+    bool _isLoose  = ele->electronID("cutBasedElectronID-Fall17-94X-V2-loose");
+    bool _isMedium = ele->electronID("cutBasedElectronID-Fall17-94X-V2-medium");
+    bool _isTight  = ele->electronID("cutBasedElectronID-Fall17-94X-V2-tight");
 
     if (_ele_ID.find("veto")   != std::string::npos && !_isVeto)   continue;
     if (_ele_ID.find("loose")  != std::string::npos && !_isLoose)  continue;

--- a/DiMuons/src/EleHelper.cc
+++ b/DiMuons/src/EleHelper.cc
@@ -4,7 +4,7 @@
 void FillEleInfos( EleInfos& _eleInfos, 
 		   const pat::ElectronCollection elesSelected,
 		   const reco::Vertex primaryVertex, const edm::Event& iEvent,
-		   const std::vector<std::array<bool, 4>> ele_ID_pass,
+		   const std::array<std::string, 5> ele_ID_names,
 		   LepMVAVars & _lepVars_ele, std::shared_ptr<TMVA::Reader> & _lepMVA_ele,
                    const double _rho, const edm::Handle<pat::JetCollection>& jets,
                    const edm::Handle<pat::PackedCandidateCollection> pfCands,
@@ -26,13 +26,13 @@ void FillEleInfos( EleInfos& _eleInfos,
 
     // Basic quality
     _eleInfo.isPF       = ele.isPF();
-    _eleInfo.isVetoID   = ele_ID_pass.at(i)[0];
-    _eleInfo.isLooseID  = ele_ID_pass.at(i)[1];
-    _eleInfo.isMediumID = ele_ID_pass.at(i)[2];
-    _eleInfo.isTightID  = ele_ID_pass.at(i)[3];
+    _eleInfo.isVetoID   = ele.electronID(ele_ID_names[0]);
+    _eleInfo.isLooseID  = ele.electronID(ele_ID_names[1]);
+    _eleInfo.isMediumID = ele.electronID(ele_ID_names[2]);
+    _eleInfo.isTightID  = ele.electronID(ele_ID_names[3]);
 
     // EGamma POG MVA quality
-    _eleInfo.mvaID = ele.userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV1Values");
+    _eleInfo.mvaID = ele.userFloat(ele_ID_names[4]);
 
     // Basic isolation
     _eleInfo.relIso         = EleCalcRelIsoPF( ele, _rho, eleEffArea, "DeltaBeta" );
@@ -91,11 +91,8 @@ void FillEleInfos( EleInfos& _eleInfos,
 
 
 pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>& eles, const reco::Vertex primaryVertex,
-				    const edm::Handle< edm::ValueMap<bool> >& ele_id_veto, const edm::Handle< edm::ValueMap<bool> >& ele_id_loose,
-				    const edm::Handle< edm::ValueMap<bool> >& ele_id_medium, const edm::Handle< edm::ValueMap<bool> >& ele_id_tight,
-				    const edm::Handle< edm::ValueMap<float> >& ele_id_mva, const std::string _ele_ID,
-				    const double _ele_pT_min, const double _ele_eta_max,
-				    std::vector<std::array<bool, 4>>& ele_ID_pass ) {
+				    const std::array<std::string, 5> ele_ID_names, const std::string _ele_ID,
+				    const double _ele_pT_min, const double _ele_eta_max ) {
   
   // Main Egamma POG page: https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPOG
   // Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaIDRecipesRun2
@@ -104,14 +101,9 @@ pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>&
   
   pat::ElectronCollection elesSelected;
   elesSelected.clear();
-  ele_ID_pass.clear();
 
   if ( !eles.isValid() ) {
     std::cout << "No valid electron collection" << std::endl;
-    return elesSelected;
-  }
-  if ( !ele_id_veto.isValid() || !ele_id_loose.isValid() || !ele_id_medium.isValid() || !ele_id_tight.isValid() ) {
-    std::cout << "No valid electron ID" << std::endl;
     return elesSelected;
   }
 
@@ -127,18 +119,12 @@ pat::ElectronCollection SelectEles( const edm::Handle<edm::View<pat::Electron>>&
     if ( ele->pt()          < _ele_pT_min  ) continue;
     if ( fabs( ele->eta() ) > _ele_eta_max ) continue;
 
-    bool _isVeto   = ele->electronID("cutBasedElectronID-Fall17-94X-V2-veto");
-    bool _isLoose  = ele->electronID("cutBasedElectronID-Fall17-94X-V2-loose");
-    bool _isMedium = ele->electronID("cutBasedElectronID-Fall17-94X-V2-medium");
-    bool _isTight  = ele->electronID("cutBasedElectronID-Fall17-94X-V2-tight");
-
-    if (_ele_ID.find("veto")   != std::string::npos && !_isVeto)   continue;
-    if (_ele_ID.find("loose")  != std::string::npos && !_isLoose)  continue;
-    if (_ele_ID.find("medium") != std::string::npos && !_isMedium) continue;
-    if (_ele_ID.find("tight")  != std::string::npos && !_isTight)  continue;
+    if (_ele_ID.find("veto")   != std::string::npos && !ele->electronID(ele_ID_names[0]) ) continue;
+    if (_ele_ID.find("loose")  != std::string::npos && !ele->electronID(ele_ID_names[1]) ) continue;
+    if (_ele_ID.find("medium") != std::string::npos && !ele->electronID(ele_ID_names[2]) ) continue;
+    if (_ele_ID.find("tight")  != std::string::npos && !ele->electronID(ele_ID_names[3]) ) continue;
 
     elesSelected.push_back(*ele);
-    ele_ID_pass.push_back( {{_isVeto, _isLoose, _isMedium, _isTight}} );
 
   }
   

--- a/DiMuons/test/DiMuons17_94X_2018_12_05.py
+++ b/DiMuons/test/DiMuons17_94X_2018_12_05.py
@@ -80,14 +80,17 @@ process.TFileService = cms.Service('TFileService', fileName = cms.string('ttH_HT
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 
-## Modeled after https://github.com/GhentAnalysis/heavyNeutrino/blob/master/multilep/python/egmSequence_cff.py
-## Have to merge V2 electron IDs using this recipe: https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_formats
-from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
-eleIDs = [ 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
-           'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff' ]
-for eleID in eleIDs: setupAllVIDIdsInModule(process, eleID, setupVIDElectronSelection)
+
+setupEgammaPostRecoSeq( process,
+                        runVID = True ,  ## Needed for 2017 V2 IDs
+                        era    = '2017-Nov17ReReco' )
+                        # eleIDModules = [ 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
+                        #                  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff' ] )
 
 
 # /////////////////////////////////////////////////////////////
@@ -136,7 +139,7 @@ print 'About to run the process path'
 ## https://github.com/pfs/TopLJets2015/blob/master/TopAnalysis/python/customizeJetTools_cff.py#L47
 ## https://github.com/pfs/TopLJets2015/blob/master/TopAnalysis/python/customizeEGM_cff.py#L67
 
-process.egamma_step = cms.Path( process.egmGsfElectronIDSequence )  ## See eleIDs above
+process.egamma_step = cms.Path( process.egammaPostRecoSeq )  ## See setupEgammaPostRecoSeq above
 process.ntuple_step = cms.Path( process.dimuons )
 
 process.schedule = cms.Schedule( process.egamma_step, process.ntuple_step )  ## , process.treeOut_step )

--- a/README.md
+++ b/README.md
@@ -2,5 +2,43 @@ PPD Analysis Guidelines
 https://docs.google.com/presentation/d/1F1ZsQqljdR4IqIJ5za2TAIVFF0eqHquopzN_jgVTdKE/edit#slide=id.g43837f3ea1_0_46
 
 
-# Ntupliser
+## Ntupliser
 X2MuMu Ntupliser
+
+## Instructions for checking out code to run master_2017_94X
+
+setenv SCRAM_ARCH slc6_amd64_gcc630
+cmsrel CMSSW_9_4_10  ## Need a release >= 9_4_10 to merge cms-egamma code (below)
+cd CMSSW_9_4_10/src
+cmsenv
+git cms-init
+git remote add cms-sw git@github.com:cms-sw/cmssw.git
+git fetch cms-sw
+
+git remote add your_username git@github.com:your_username/cmssw.git
+git remote add Ntupliser git@github.com:UFLX2MuMu/Ntupliser.git
+
+git clone https://github.com/UFLX2MuMu/Ntupliser.git
+
+## Twiki not updated recently (as of 18.10.2018)
+## https://twiki.cern.ch/twiki/bin/view/CMS/MuonScaleResolKalman
+git clone https://github.com/bachtis/Analysis.git -b KaMuCa_V4 KaMuCa
+
+## Add following lines to the beginning of KaMuCa/Calibration/interface/KalmanMuonCalibrator.h
+#ifndef KalmanMuonCalibrator_h
+#define KalmanMuonCalibrator_h
+## and the following line to the end:
+#endif // #define KalmanMuonCalibrator_h
+
+## Get most recent electron IDs, following:
+## https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_formats
+## https://twiki.cern.ch/twiki/bin/view/CMS/EgammaMiniAODV2#2017_MiniAOD_V2
+## https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V1
+git cms-merge-topic cms-egamma:EgammaID_949             # If you want the V2 IDs, otherwise skip
+git cms-merge-topic cms-egamma:EgammaPostRecoTools_940  # Just adds an extra file for an easier setup function
+
+scram b -j 6
+
+cd Ntupliser
+git checkout -b master_2017_94X
+scram b -j 6


### PR DESCRIPTION
A bug was present in the storage of the EGamma POG electron MVA ID.  Also updated to the latest recommended EGamma recipe, replacing ValueMaps with "electronID" and "userFloat" access of ID values.

@bortigno please take a look.