### PR TITLE
Issue 50 l1 prefiring

### DIFF
--- a/DiMuons/crab/templates/EDAnalyzer.py
+++ b/DiMuons/crab/templates/EDAnalyzer.py
@@ -55,6 +55,18 @@ if samp.isData:
 process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
 
 # /////////////////////////////////////////////////////////////
+# L1 Prefiring maps
+# from https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
+# /////////////////////////////////////////////////////////////
+
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"),
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
+
+# /////////////////////////////////////////////////////////////
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 
@@ -114,6 +126,7 @@ setupEgammaPostRecoSeq( process,
 # /////////////////////////////////////////////////////////////
     
 process.p = cms.Path( 
+  process.prefiringweight *
   process.egammaPostRecoSeq *
   process.fullPatMetSequenceModifiedMET *
   process.dimuons )

--- a/DiMuons/plugins/UFDiMuonsAnalyzer.h
+++ b/DiMuons/plugins/UFDiMuonsAnalyzer.h
@@ -68,6 +68,10 @@ public:
   TFile* _PU_wgt_file;
   int _GEN_wgt;    // +1 or -1 weight for nlo samples, -1 simulates interference when filling histos
 
+  //L1 ECAL prefiring event weights and systematic uncertainty
+  float _prefiringweight; 
+  float _prefiringweightup; 
+  float _prefiringweightdown;
 
   ///////////////////////////////////////////////////////////
   // Structs  ==============================================
@@ -357,6 +361,11 @@ private:
 
   edm::EDGetTokenT<edm::TriggerResults> _trigResultsToken;
   edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> _trigObjsToken;
+
+  // L1 ECAL prefiring event weights and systematic variations
+  edm::EDGetTokenT< double > _prefweight_token;
+  edm::EDGetTokenT< double > _prefweightup_token;
+  edm::EDGetTokenT< double > _prefweightdown_token;
 
   // Event flags
   edm::EDGetTokenT< edm::TriggerResults > _evtFlagsToken;

--- a/DiMuons/test/test_crab_config.py
+++ b/DiMuons/test/test_crab_config.py
@@ -1,0 +1,122 @@
+# =============================================================#
+# X2MuMuAnalyzer configuration file                            #
+# =============================================================#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("dimuons")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+# /////////////////////////////////////////////////////////////
+# Get a sample from our collection of samples
+# /////////////////////////////////////////////////////////////
+
+from python.Samples_2017_94X_v2 import H2Mu_gg_125_NLO as samp
+
+if samp.isData:
+    print '\nRunning over data sample %s' % samp.name
+else:
+    print '\nRunning over MC sample %s' % samp.name
+print '  * From DAS: %s' % samp.DAS
+
+# /////////////////////////////////////////////////////////////
+# Global tag, automatically retrieved from the imported sample
+# /////////////////////////////////////////////////////////////
+
+print '\nLoading Global Tag: ' + samp.GT
+process.GlobalTag.globaltag = samp.GT
+
+# /////////////////////////////////////////////////////////////
+# ------------ PoolSource -------------
+# /////////////////////////////////////////////////////////////
+
+readFiles = cms.untracked.vstring();
+## Get list of local files from the sample we loaded (not used in crab)
+readFiles.extend(samp.files);
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.source = cms.Source("PoolSource", fileNames = readFiles)
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()
+
+## Use a JSON file for local running (not used in crab)
+if samp.isData:
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = samp.JSON).getVLuminosityBlockRange()
+
+# /////////////////////////////////////////////////////////////
+# Save output with TFileService
+# /////////////////////////////////////////////////////////////
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
+
+# /////////////////////////////////////////////////////////////
+# Load electron IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( 
+  process,
+  runVID = True ,  ## Needed for 2017 V2 IDs
+  era    = '2017-Nov17ReReco' 
+  )
+
+# /////////////////////////////////////////////////////////////
+# Correct MET from EE noise
+# /////////////////////////////////////////////////////////////
+# More info on https://indico.cern.ch/event/759372/contributions/3149378/attachments/1721436/2802416/metreport.pdf
+
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+runMetCorAndUncFromMiniAOD (
+  process,
+  isData = samp.isData,
+  fixEE2017 = True,
+  fixEE2017Params = {'userawPt':True,'ptThreshold':50.0,'minEtaThreshold':2.65,'maxEtaThreshold':3.139},
+  postfix = "ModifiedMET"
+  )
+
+# /////////////////////////////////////////////////////////////
+# Load Analyzer
+# /////////////////////////////////////////////////////////////
+
+if samp.isData:
+  process.load("Ntupliser.DiMuons.Analyzer_cff")
+else:
+  process.load("Ntupliser.DiMuons.Analyzer_MC_cff")
+
+# /////////////////////////////////////////////////////////////
+# Electron Cut Based IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( process,
+                        runVID = True ,  ## Needed for 2017 V2 IDs
+                        era    = '2017-Nov17ReReco' )
+ 
+# /////////////////////////////////////////////////////////////
+# Set the order of operations
+# /////////////////////////////////////////////////////////////
+    
+process.p = cms.Path( 
+  process.egammaPostRecoSeq *
+  process.fullPatMetSequenceModifiedMET *
+  process.dimuons )
+

--- a/DiMuons/test/test_crab_config.py
+++ b/DiMuons/test/test_crab_config.py
@@ -57,6 +57,18 @@ if samp.isData:
 process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
 
 # /////////////////////////////////////////////////////////////
+# L1 Prefiring maps
+# from https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
+# /////////////////////////////////////////////////////////////
+
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"),
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
+
+# /////////////////////////////////////////////////////////////
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 
@@ -116,6 +128,7 @@ setupEgammaPostRecoSeq( process,
 # /////////////////////////////////////////////////////////////
     
 process.p = cms.Path( 
+  process.prefiringweight *
   process.egammaPostRecoSeq *
   process.fullPatMetSequenceModifiedMET *
   process.dimuons )

--- a/DiMuons/test/test_ntupliser_data.py
+++ b/DiMuons/test/test_ntupliser_data.py
@@ -1,0 +1,122 @@
+# =============================================================#
+# X2MuMuAnalyzer configuration file                            #
+# =============================================================#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("dimuons")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+# /////////////////////////////////////////////////////////////
+# Get a sample from our collection of samples
+# /////////////////////////////////////////////////////////////
+
+from python.Samples_2017_94X_v2 import SingleMu_2017B as samp
+
+if samp.isData:
+    print '\nRunning over data sample %s' % samp.name
+else:
+    print '\nRunning over MC sample %s' % samp.name
+print '  * From DAS: %s' % samp.DAS
+
+# /////////////////////////////////////////////////////////////
+# Global tag, automatically retrieved from the imported sample
+# /////////////////////////////////////////////////////////////
+
+print '\nLoading Global Tag: ' + samp.GT
+process.GlobalTag.globaltag = samp.GT
+
+# /////////////////////////////////////////////////////////////
+# ------------ PoolSource -------------
+# /////////////////////////////////////////////////////////////
+
+readFiles = cms.untracked.vstring();
+## Get list of local files from the sample we loaded (not used in crab)
+readFiles.extend(samp.files);
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.source = cms.Source("PoolSource", fileNames = readFiles)
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()
+
+## Use a JSON file for local running (not used in crab)
+if samp.isData:
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = samp.JSON).getVLuminosityBlockRange()
+
+# /////////////////////////////////////////////////////////////
+# Save output with TFileService
+# /////////////////////////////////////////////////////////////
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
+
+# /////////////////////////////////////////////////////////////
+# Load electron IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( 
+  process,
+  runVID = True ,  ## Needed for 2017 V2 IDs
+  era    = '2017-Nov17ReReco' 
+  )
+
+# /////////////////////////////////////////////////////////////
+# Correct MET from EE noise
+# /////////////////////////////////////////////////////////////
+# More info on https://indico.cern.ch/event/759372/contributions/3149378/attachments/1721436/2802416/metreport.pdf
+
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+runMetCorAndUncFromMiniAOD (
+  process,
+  isData = samp.isData,
+  fixEE2017 = True,
+  fixEE2017Params = {'userawPt':True,'ptThreshold':50.0,'minEtaThreshold':2.65,'maxEtaThreshold':3.139},
+  postfix = "ModifiedMET"
+  )
+
+# /////////////////////////////////////////////////////////////
+# Load Analyzer
+# /////////////////////////////////////////////////////////////
+
+if samp.isData:
+  process.load("Ntupliser.DiMuons.Analyzer_cff")
+else:
+  process.load("Ntupliser.DiMuons.Analyzer_MC_cff")
+
+# /////////////////////////////////////////////////////////////
+# Electron Cut Based IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( process,
+                        runVID = True ,  ## Needed for 2017 V2 IDs
+                        era    = '2017-Nov17ReReco' )
+ 
+# /////////////////////////////////////////////////////////////
+# Set the order of operations
+# /////////////////////////////////////////////////////////////
+    
+process.p = cms.Path( 
+  process.egammaPostRecoSeq *
+  process.fullPatMetSequenceModifiedMET *
+  process.dimuons )
+

--- a/DiMuons/test/test_ntupliser_data.py
+++ b/DiMuons/test/test_ntupliser_data.py
@@ -16,7 +16,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 # Get a sample from our collection of samples
 # /////////////////////////////////////////////////////////////
 
-from python.Samples_2017_94X_v2 import SingleMu_2017B as samp
+from python.Samples_2017_94X_v2 import SingleMu_2017C as samp
 
 if samp.isData:
     print '\nRunning over data sample %s' % samp.name
@@ -54,7 +54,7 @@ if samp.isData:
 # Save output with TFileService
 # /////////////////////////////////////////////////////////////
 
-process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
+process.TFileService = cms.Service("TFileService", fileName = cms.string("test_ntuple_data_Run2017C.root") )
 
 # /////////////////////////////////////////////////////////////
 # L1 Prefiring maps
@@ -128,6 +128,7 @@ setupEgammaPostRecoSeq( process,
 # /////////////////////////////////////////////////////////////
     
 process.p = cms.Path( 
+  process.prefiringweight *
   process.egammaPostRecoSeq *
   process.fullPatMetSequenceModifiedMET *
   process.dimuons )

--- a/DiMuons/test/test_ntupliser_data.py
+++ b/DiMuons/test/test_ntupliser_data.py
@@ -57,6 +57,18 @@ if samp.isData:
 process.TFileService = cms.Service("TFileService", fileName = cms.string("tuple.root") )
 
 # /////////////////////////////////////////////////////////////
+# L1 Prefiring maps
+# from https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
+# /////////////////////////////////////////////////////////////
+
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"),
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
+
+# /////////////////////////////////////////////////////////////
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 

--- a/DiMuons/test/test_ntupliser_mc.py
+++ b/DiMuons/test/test_ntupliser_mc.py
@@ -57,6 +57,18 @@ if samp.isData:
 process.TFileService = cms.Service("TFileService", fileName = cms.string("ggH_125_NLO_test.root") )
 
 # /////////////////////////////////////////////////////////////
+# L1 Prefiring maps
+# from https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
+# /////////////////////////////////////////////////////////////
+
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"),
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
+
+# /////////////////////////////////////////////////////////////
 # Load electron IDs
 # /////////////////////////////////////////////////////////////
 
@@ -116,6 +128,7 @@ setupEgammaPostRecoSeq( process,
 # /////////////////////////////////////////////////////////////
     
 process.p = cms.Path( 
+  process.prefiringweight *
   process.egammaPostRecoSeq *
   process.fullPatMetSequenceModifiedMET *
   process.dimuons )

--- a/DiMuons/test/test_ntupliser_mc.py
+++ b/DiMuons/test/test_ntupliser_mc.py
@@ -1,0 +1,122 @@
+# =============================================================#
+# X2MuMuAnalyzer configuration file                            #
+# =============================================================#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("dimuons")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+# /////////////////////////////////////////////////////////////
+# Get a sample from our collection of samples
+# /////////////////////////////////////////////////////////////
+
+from python.Samples_2017_94X_v2 import H2Mu_gg_125_NLO as samp
+
+if samp.isData:
+    print '\nRunning over data sample %s' % samp.name
+else:
+    print '\nRunning over MC sample %s' % samp.name
+print '  * From DAS: %s' % samp.DAS
+
+# /////////////////////////////////////////////////////////////
+# Global tag, automatically retrieved from the imported sample
+# /////////////////////////////////////////////////////////////
+
+print '\nLoading Global Tag: ' + samp.GT
+process.GlobalTag.globaltag = samp.GT
+
+# /////////////////////////////////////////////////////////////
+# ------------ PoolSource -------------
+# /////////////////////////////////////////////////////////////
+
+readFiles = cms.untracked.vstring();
+## Get list of local files from the sample we loaded (not used in crab)
+readFiles.extend(samp.files);
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.source = cms.Source("PoolSource", fileNames = readFiles)
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()
+
+## Use a JSON file for local running (not used in crab)
+if samp.isData:
+    import FWCore.PythonUtilities.LumiList as LumiList
+    process.source.lumisToProcess = LumiList.LumiList(filename = samp.JSON).getVLuminosityBlockRange()
+
+# /////////////////////////////////////////////////////////////
+# Save output with TFileService
+# /////////////////////////////////////////////////////////////
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("ggH_125_NLO_test.root") )
+
+# /////////////////////////////////////////////////////////////
+# Load electron IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( 
+  process,
+  runVID = True ,  ## Needed for 2017 V2 IDs
+  era    = '2017-Nov17ReReco' 
+  )
+
+# /////////////////////////////////////////////////////////////
+# Correct MET from EE noise
+# /////////////////////////////////////////////////////////////
+# More info on https://indico.cern.ch/event/759372/contributions/3149378/attachments/1721436/2802416/metreport.pdf
+
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+runMetCorAndUncFromMiniAOD (
+  process,
+  isData = samp.isData,
+  fixEE2017 = True,
+  fixEE2017Params = {'userawPt':True,'ptThreshold':50.0,'minEtaThreshold':2.65,'maxEtaThreshold':3.139},
+  postfix = "ModifiedMET"
+  )
+
+# /////////////////////////////////////////////////////////////
+# Load Analyzer
+# /////////////////////////////////////////////////////////////
+
+if samp.isData:
+  process.load("Ntupliser.DiMuons.Analyzer_cff")
+else:
+  process.load("Ntupliser.DiMuons.Analyzer_MC_cff")
+
+# /////////////////////////////////////////////////////////////
+# Electron Cut Based IDs
+# /////////////////////////////////////////////////////////////
+
+## Following https://twiki.cern.ch/twiki/bin/view/CMS/EgammaPostRecoRecipes#Running_on_2017_MiniAOD_V2
+## More complete recipe documentation: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+##               - In particular here: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#VID_based_recipe_provides_pass_f
+
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+setupEgammaPostRecoSeq( process,
+                        runVID = True ,  ## Needed for 2017 V2 IDs
+                        era    = '2017-Nov17ReReco' )
+ 
+# /////////////////////////////////////////////////////////////
+# Set the order of operations
+# /////////////////////////////////////////////////////////////
+    
+process.p = cms.Path( 
+  process.egammaPostRecoSeq *
+  process.fullPatMetSequenceModifiedMET *
+  process.dimuons )
+


### PR DESCRIPTION
Added l1t pre-firing weights for 2017. (should be eventually back ported to 2016). not needed for 2018.
The weights inclusion follows the recipe here 
https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe

The weights and their uncertainties appear only in the mc tuples in the branches:
l1pref_wgt
l1pref_wgt_up
l1pref_wgt_down

The uncertainty is taken as the maximum between 20 percents of the object prefiring probability and the statistical uncertainty associated to the considered bin in the prefiring map.
