### PR TITLE
Port issue 84 2017 cherry pick

### DIFF
--- a/DiMuons/interface/MuPairHelper.h
+++ b/DiMuons/interface/MuPairHelper.h
@@ -29,6 +29,15 @@ void FillMuPairMasses( muVecSys& mu1_vec, muVecSys& mu2_vec, pairVecSys& pair_ve
 		       double& massErr, const double MASS_MUON,
 		       const MuonInfo _mu1, const MuonInfo _mu2,
 		       const double _mu1_pt, const double _mu2_pt,
+		       const double _mu1_ptErr, const double _mu2_ptErr,
+                       const float _mu1_phi, const float _mu2_phi,
+                       const float _mu1_eta, const float _mu2_eta );
+
+
+void FillMuPairMasses( muVecSys& mu1_vec, muVecSys& mu2_vec, pairVecSys& pair_vec, 
+		       double& massErr, const double MASS_MUON,
+		       const MuonInfo _mu1, const MuonInfo _mu2,
+		       const double _mu1_pt, const double _mu2_pt,
 		       const double _mu1_ptErr, const double _mu2_ptErr );
 
 #endif  // #ifndef MU_PAIR_HELPER

--- a/DiMuons/interface/MuonInfo.h
+++ b/DiMuons/interface/MuonInfo.h
@@ -47,6 +47,7 @@ struct MuonInfo {
   Float_t d0_PV        = -999;
   Float_t dz_PV        = -999;
   Float_t d0_PV_kinfit = -999;
+  Float_t d0_BS_kinfit = -999;
   Float_t dz_PV_kinfit = -999;
   Float_t chi2_kinfit  = -999;
   Int_t   ndf_kinfit   = -999;

--- a/DiMuons/interface/MuonInfo.h
+++ b/DiMuons/interface/MuonInfo.h
@@ -22,6 +22,8 @@ struct MuonInfo {
   Double_t ptErr  = -999;
   Double_t eta    = -999;
   Double_t phi    = -999;
+  Double_t phi_kinfit = -999;
+  Double_t eta_kinfit = -999;
 
   Double_t pt_trk    = -999;
   Double_t ptErr_trk = -999;

--- a/DiMuons/src/MuPairHelper.cc
+++ b/DiMuons/src/MuPairHelper.cc
@@ -145,7 +145,9 @@ void FillMuPairInfos( MuPairInfos& _pairInfos, const MuonInfos _muonInfos ) {
       FillMuPairMasses( mu1_vec, mu2_vec, pair_vec, massErr, MASS_MUON, 
 		      _muonInfos.at(iMu1), _muonInfos.at(iMu2),
 		      _muonInfos.at(iMu1).pt_kinfit, _muonInfos.at(iMu2).pt_kinfit,
-		      _muonInfos.at(iMu1).ptErr_kinfit, _muonInfos.at(iMu2).ptErr_kinfit );
+		      _muonInfos.at(iMu1).ptErr_kinfit, _muonInfos.at(iMu2).ptErr_kinfit,
+                      _muonInfos.at(iMu1).phi_kinfit, _muonInfos.at(iMu2).phi_kinfit,
+                      _muonInfos.at(iMu1).eta_kinfit, _muonInfos.at(iMu2).eta_kinfit );
       
       _pairInfo.mass_kinfit    = pair_vec.nom.M();
       _pairInfo.massErr_kinfit = massErr;
@@ -200,6 +202,35 @@ bool pair_is_OS( std::pair< bool, std::pair<int, int> > i,
   return (i.first || !j.first);
 }
 
+void FillMuPairMasses( muVecSys& mu1_vec, muVecSys& mu2_vec, pairVecSys& pair_vec, 
+		     double& massErr, const double MASS_MUON,
+		     const MuonInfo _mu1, const MuonInfo _mu2, 
+		     const double _mu1_pt, const double _mu2_pt,
+		     const double _mu1_ptErr, const double _mu2_ptErr,
+                     const float _mu1_phi, const float _mu2_phi,
+                     const float _mu1_eta, const float _mu2_eta ) {
+
+  mu1_vec.nom.SetPtEtaPhiM(_mu1_pt, _mu1_eta, _mu1_phi, MASS_MUON);
+  mu2_vec.nom.SetPtEtaPhiM(_mu2_pt, _mu2_eta, _mu2_phi, MASS_MUON);
+  
+  mu1_vec.up.SetPtEtaPhiM(_mu1_pt + _mu1_ptErr, _mu1_eta, _mu1_phi, MASS_MUON);
+  mu2_vec.up.SetPtEtaPhiM(_mu2_pt + _mu2_ptErr, _mu2_eta, _mu2_phi, MASS_MUON);
+  
+  mu1_vec.down.SetPtEtaPhiM(_mu1_pt - _mu1_ptErr, _mu1_eta, _mu1_phi, MASS_MUON);
+  mu2_vec.down.SetPtEtaPhiM(_mu2_pt - _mu2_ptErr, _mu2_eta, _mu2_phi, MASS_MUON);
+  
+  pair_vec.nom   = mu1_vec.nom  + mu2_vec.nom;
+  pair_vec.up1   = mu1_vec.up   + mu2_vec.nom;
+  pair_vec.down1 = mu1_vec.down + mu2_vec.nom;
+  pair_vec.up2   = mu1_vec.nom  + mu2_vec.up;
+  pair_vec.down2 = mu1_vec.nom  + mu2_vec.down;
+  
+  massErr = sqrt( pow(pair_vec.nom.M() - pair_vec.up1.M(),   2) +
+		  pow(pair_vec.nom.M() - pair_vec.down1.M(), 2) + 
+		  pow(pair_vec.nom.M() - pair_vec.up2.M(),   2) + 
+		  pow(pair_vec.nom.M() - pair_vec.down2.M(), 2) ) / 2.;
+  
+}
 void FillMuPairMasses( muVecSys& mu1_vec, muVecSys& mu2_vec, pairVecSys& pair_vec, 
 		     double& massErr, const double MASS_MUON,
 		     const MuonInfo _mu1, const MuonInfo _mu2, 

--- a/DiMuons/src/MuonHelper.cc
+++ b/DiMuons/src/MuonHelper.cc
@@ -278,19 +278,12 @@ void FillMuonInfos( MuonInfos& _muonInfos,
       _muonInfo.chi2_kinfit = dimu_vertex->chiSquared();
       _muonInfo.ndf_kinfit =  dimu_vertex->degreesOfFreedom(); 
       if(i==0){ //first muon
-//        GlobalVector direction(mu1_tlv.Px(),mu1_tlv.Py(),mu1_tlv.Pz());
-//        GlobalVector direction2d(mu1_tlv.Px(),mu1_tlv.Py(), 0);
-//        GlobalVector bs_corrected( beamSpotHandle->position().x() - mu1_position.x(), beamSpotHandle->position().y() - mu1_position.y(), 0 );
-        GlobalVector direction(muon.innerTrack()->px(),muon.innerTrack()->py(),muon.innerTrack()->pz());
-        GlobalVector direction2d(muon.innerTrack()->px(),muon.innerTrack()->py(), 0);
-        GlobalVector bs_corrected( beamSpotHandle->position().x() + muon.innerTrack()->vx(), beamSpotHandle->position().y() + muon.innerTrack()->vy(), 0 );
-        //_muonInfo.d0_BS_kinfit = direction2d.dot(bs_corrected)/direction2d.mag();
-        _muonInfo.d0_BS_kinfit = ( - (muon.innerTrack()->vx() - beamSpotHandle->position().x() ) * muon.innerTrack()->py() + ( muon.innerTrack()->vy() - beamSpotHandle->position().y() ) * muon.innerTrack()->px() / muon.innerTrack()->pt() ) ;
-        std::cout << "d0_BS" << muon.innerTrack()->dxy( beamSpotHandle->position() ) << std::endl << "kinfit d0_BS : " << _muonInfo.d0_BS_kinfit << std::endl << std::endl;
+        GlobalVector direction(mu1_tlv.Px(),mu1_tlv.Py(),mu1_tlv.Pz());
         float prod = IPVec.dot(direction);
         int sign = (prod>=0) ? 1. : -1.;
         _muonInfo.d0_PV_kinfit *= sign;
         _muonInfo.dz_PV_kinfit *= sign;
+        _muonInfo.d0_BS_kinfit = ( - (mu1_position.x() - beamSpotHandle->position().x() ) * mu1_tlv.Py() + ( mu1_position.y() - beamSpotHandle->position().y() ) * mu1_tlv.Px() ) / mu1_tlv.Pt()  ;
         _muonInfo.pt_kinfit  = mu1_tlv.Pt();
         _muonInfo.phi_kinfit = mu1_tlv.Phi();
         _muonInfo.eta_kinfit = mu1_tlv.Eta();
@@ -298,13 +291,11 @@ void FillMuonInfos( MuonInfos& _muonInfos,
       }
       if(i==1){ //second muon
         GlobalVector direction(mu2_tlv.Px(),mu2_tlv.Py(),mu2_tlv.Pz()); 
-        GlobalVector direction2d(mu2_tlv.Px(),mu2_tlv.Py(), 0);
-        GlobalVector bs_corrected( beamSpotHandle->position().x() - mu2_position.x(), beamSpotHandle->position().y() - mu2_position.y(), 0 );
-        _muonInfo.d0_BS_kinfit = direction2d.dot(bs_corrected)/direction2d.mag();
         float prod = IPVec.dot(direction);
         int sign = (prod>=0) ? 1. : -1.;
         _muonInfo.d0_PV_kinfit *= sign;
         _muonInfo.dz_PV_kinfit *= sign;
+        _muonInfo.d0_BS_kinfit = ( - (mu2_position.x() - beamSpotHandle->position().x() ) * mu2_tlv.Py() + ( mu2_position.y() - beamSpotHandle->position().y() ) * mu2_tlv.Px() ) / mu2_tlv.Pt()  ;
         _muonInfo.pt_kinfit  = mu2_tlv.Pt();
         _muonInfo.phi_kinfit = mu2_tlv.Phi();
         _muonInfo.eta_kinfit = mu2_tlv.Eta();
@@ -316,6 +307,7 @@ void FillMuonInfos( MuonInfos& _muonInfos,
         _muonInfo.ptErr_kinfit = muon.muonBestTrack()->ptError();
         _muonInfo.phi_kinfit = muon.muonBestTrack()->phi();
         _muonInfo.eta_kinfit = muon.muonBestTrack()->eta(); 
+        _muonInfo.d0_BS_kinfit  = muon.innerTrack()->dxy( beamSpotHandle->position() );
     }
 
     //DEBUG: Checking dO

--- a/DiMuons/src/MuonHelper.cc
+++ b/DiMuons/src/MuonHelper.cc
@@ -277,6 +277,8 @@ void FillMuonInfos( MuonInfos& _muonInfos,
         _muonInfo.d0_PV_kinfit *= sign;
         _muonInfo.dz_PV_kinfit *= sign;
         _muonInfo.pt_kinfit  = mu1_tlv.Pt();
+        _muonInfo.phi_kinfit = mu1_tlv.Phi();
+        _muonInfo.eta_kinfit = mu1_tlv.Eta();
         _muonInfo.ptErr_kinfit = mu1_ptErr_kinfit;
       }
       if(i==1){ //second muon
@@ -286,12 +288,16 @@ void FillMuonInfos( MuonInfos& _muonInfos,
         _muonInfo.d0_PV_kinfit *= sign;
         _muonInfo.dz_PV_kinfit *= sign;
         _muonInfo.pt_kinfit  = mu2_tlv.Pt();
+        _muonInfo.phi_kinfit = mu2_tlv.Phi();
+        _muonInfo.eta_kinfit = mu2_tlv.Eta();
         _muonInfo.ptErr_kinfit = mu2_ptErr_kinfit;
      }
     } 
     else{ // if the kinfit was not succesful for this muon use the muonBestTrack 
         _muonInfo.pt_kinfit = muon.muonBestTrack()->pt();
-        _muonInfo.ptErr_kinfit = muon.muonBestTrack()->ptError(); 
+        _muonInfo.ptErr_kinfit = muon.muonBestTrack()->ptError();
+        _muonInfo.phi_kinfit = muon.muonBestTrack()->phi();
+        _muonInfo.eta_kinfit = muon.muonBestTrack()->eta(); 
     }
 
     //DEBUG: Checking dO


### PR DESCRIPTION
This PR port the development of issue #84 - kinfit phi, eta, and d0_BS_kinfit to 2017.

More details on the workflow used in the issue #84 comments.

Validation plots in attachment for MC (gg125) [1] and data (2017C) [2]. Things seem ok.

[1]
![Screenshot 2019-10-29 at 14 05 23](https://user-images.githubusercontent.com/8289819/67770544-e2294e00-fa56-11e9-9353-903b092b7730.png)

[2]
![Screenshot 2019-10-29 at 14 11 17](https://user-images.githubusercontent.com/8289819/67770561-e9505c00-fa56-11e9-8bdb-b8e37f9b402c.png)
