### PR TITLE
Issue 127 muon fit bs 2018

### DIFF
--- a/DiMuons/interface/MuPairInfo.h
+++ b/DiMuons/interface/MuPairInfo.h
@@ -55,6 +55,10 @@ struct MuPairInfo {
   Double_t mass_Roch_sys_down = -999;
   Double_t pt_Roch_sys_down   = -999;
 
+  Double_t mass_bs    = -999;
+  Double_t massErr_bs = -999;
+  Double_t pt_bs      = -999;
+
 };
 
 typedef std::vector<MuPairInfo> MuPairInfos;

--- a/DiMuons/interface/MuonHelper.h
+++ b/DiMuons/interface/MuonHelper.h
@@ -10,6 +10,8 @@
 #include "Ntupliser/DiMuons/interface/GenMuonInfo.h"
 #include "Ntupliser/DiMuons/interface/LepMVA.h"
 
+#include "RecoVertex/KalmanVertexFit/interface/SingleTrackVertexConstraint.h"
+
 // Classes for json handling
 #include "boost/property_tree/ptree.hpp"
 #include "boost/property_tree/json_parser.hpp"
@@ -36,6 +38,11 @@ pat::MuonCollection SelectMuons( const edm::Handle<pat::MuonCollection>& muons,
 				 const double _muon_pT_min, const double _muon_eta_max, const double _muon_trig_dR,
 				 const bool _muon_use_pfIso, const double _muon_iso_dR, const double _muon_iso_max,
 				 const double _rho, EffectiveAreas muEffArea );
+
+
+//For the fit with the BS
+OAEParametrizedMagneticField *paramField = new OAEParametrizedMagneticField("3_8T");
+reco::TransientTrack getTransientTrack(const reco::TrackRef& trackRef);
 
 bool MuonIsLoose ( const pat::Muon muon );
 bool MuonIsMedium( const pat::Muon muon );

--- a/DiMuons/interface/MuonInfo.h
+++ b/DiMuons/interface/MuonInfo.h
@@ -42,6 +42,11 @@ struct MuonInfo {
   Double_t pt_Roch_sys_up    = -999;
   Double_t pt_Roch_sys_down  = -999;
 
+  Float_t pt_bs        = -999; 
+  Float_t phi_bs       = -999;
+  Float_t ptErr_bs     = -999; 
+  Float_t chi2_bs      = -999;
+
   Float_t d0_BS        = -999;
   Float_t dz_BS        = -999;
   Float_t d0_PV        = -999;

--- a/DiMuons/src/MuPairHelper.cc
+++ b/DiMuons/src/MuPairHelper.cc
@@ -188,6 +188,20 @@ void FillMuPairInfos( MuPairInfos& _pairInfos, const MuonInfos _muonInfos ) {
       _pairInfo.pt_Roch_sys_down   = pair_vec.nom.Pt();
     }
 
+    // Beamspot constrained 
+    if ( _muonInfos.at(iMu1).pt_bs > 0 && _muonInfos.at(iMu2).pt_bs > 0 ) {
+      FillMuPairMasses( mu1_vec, mu2_vec, pair_vec, massErr, MASS_MUON, 
+		      _muonInfos.at(iMu1),          _muonInfos.at(iMu2),
+		      _muonInfos.at(iMu1).pt_bs,    _muonInfos.at(iMu2).pt_bs,
+		      _muonInfos.at(iMu1).ptErr_bs, _muonInfos.at(iMu2).ptErr_bs,
+                      _muonInfos.at(iMu1).phi_bs,   _muonInfos.at(iMu2).phi_bs,
+                      _muonInfos.at(iMu1).eta,      _muonInfos.at(iMu2).eta   );
+      
+      _pairInfo.mass_bs    = pair_vec.nom.M();
+      _pairInfo.massErr_bs = massErr;
+      _pairInfo.pt_bs      = pair_vec.nom.Pt();
+    }
+ 
     _pairInfos.push_back( _pairInfo );
   } // End loop: for (int i = 0; i < isOS.size(); i++)
   

--- a/DiMuons/src/MuonHelper.cc
+++ b/DiMuons/src/MuonHelper.cc
@@ -209,7 +209,7 @@ void FillMuonInfos( MuonInfos& _muonInfos,
       // Beamspot constrained muons
       // Refitting track with BS
       const GlobalPoint beamspot(beamSpotHandle->position().x(), beamSpotHandle->position().y(), beamSpotHandle->position().z() ) ;
-      const GlobalError beamspot_error(beamSpotHandle->covariance3D()); // (beamSpotHandle->rotatedCovariance3D()); // should it be the covariance3D() or rotatedCovariance3D() like in https://github.com/cms-sw/cmssw/blob/f6e0d5cad8bfd5646c03b8c203df10aaba5618e5/RecoVertex/VertexPrimitives/interface/VertexState.h ? - PB 04.05.20
+      const GlobalError beamspot_error(beamSpotHandle->rotatedCovariance3D()); // (beamSpotHandle->covariance3D()); // should it be the covariance3D() or rotatedCovariance3D() like in https://github.com/cms-sw/cmssw/blob/f6e0d5cad8bfd5646c03b8c203df10aaba5618e5/RecoVertex/VertexPrimitives/interface/VertexState.h ? - PB 04.05.20
       SingleTrackVertexConstraint mu_w_bs;
       const reco::TransientTrack ttm = getTransientTrack(muon.track());
       boost::tuple<bool, reco::TransientTrack, float> bs_fit_result = mu_w_bs.constrain(ttm,beamspot,beamspot_error);

--- a/DiMuons/src/MuonHelper.cc
+++ b/DiMuons/src/MuonHelper.cc
@@ -18,6 +18,9 @@ void FillMuonInfos( MuonInfos& _muonInfos,
 		    const edm::Handle<pat::PackedCandidateCollection> pfCands,
 		    EffectiveAreas muEffArea ) {
 
+
+
+
   // std::cout << "\nInside FillMuonInfos" << std::endl;
 
   double const MASS_MUON = 0.105658367; // GeV/c^2
@@ -25,6 +28,7 @@ void FillMuonInfos( MuonInfos& _muonInfos,
   _muonInfos.clear();
   int nMuons = muonsSelected.size();
 
+ 
 
   // Testing Kinematic fit : Needs to be integrated in the Ntupliser data format - PB 10.09.2018
 
@@ -118,6 +122,16 @@ void FillMuonInfos( MuonInfos& _muonInfos,
       std::cout << "ERROR: The muon is NOT global NOR tracker ?!?\n";
       continue;
     }
+
+
+    // Refitting track with BS
+  
+    const GlobalPoint beamspot(0,0,0);
+    const GlobalError beamspot_error(0.01,0,0.01,0,0,0.001);
+    SingleTrackVertexConstraint mu_w_bs;
+    const reco::TransientTrack ttm = getTransientTrack(muon.track());
+    mu_w_bs.constrain(ttm,beamspot,beamspot_error);
+ 
 
     // Basic kinematics
     // "muon.pt()" returns PF quantities if PF is available - and all loose/med/tight muons are PF
@@ -420,6 +434,15 @@ pat::MuonCollection SelectMuons( const edm::Handle<pat::MuonCollection>& muons,
   
   return muonsSelected;
 }
+
+
+//The reconstructed muon trajectories 
+reco::TransientTrack getTransientTrack(const reco::TrackRef& trackRef) {
+
+      reco::TransientTrack transientTrack(trackRef, paramField);
+      return transientTrack;
+}
+ 
 
 bool MuonIsLoose ( const pat::Muon muon ) {
   bool _isLoose = ( muon.isPFMuon() && ( muon.isGlobalMuon() || muon.isTrackerMuon() ) );


### PR DESCRIPTION
Adding muon pt, phi, ptErr and muPairs mass, massErr, pt, ptErr using the refitted track with the beamspot constraint.

Test ntuples are available in 

```/eos/cms/store/user/bortigno/h2mm/ntuples/2018/102X/prod-v18.2.0.skim3l-4-gbde17c1/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/H2Mu_gg/200506_123412/0000/*root```

Some validation plots:

[hmass_bs_ggh18bsr_hadded_inclusive.pdf](https://github.com/UFLX2MuMu/Ntupliser/files/4610495/hmass_bs_ggh18bsr_hadded_inclusive.pdf)
[hmass_bs_geoFit_ggh18bsr_hadded_inclusive.pdf](https://github.com/UFLX2MuMu/Ntupliser/files/4610508/hmass_bs_geoFit_ggh18bsr_hadded_inclusive.pdf)
![hmass_bs_geoFit_ggh18bsr_hadded_inclusive](https://user-images.githubusercontent.com/8289819/81579776-daa31400-93ac-11ea-94de-f5ecb0059a57.png)
![hmass_bs_ggh18bsr_hadded_inclusive](https://user-images.githubusercontent.com/8289819/81579836-edb5e400-93ac-11ea-86d7-80513ddb8af1.png)

