### PR TITLE
Fixing crab config template to remove getUsernameFromSiteDB

### DIFF
--- a/DiMuons/crab/templates/crab_config.py
+++ b/DiMuons/crab/templates/crab_config.py
@@ -1,5 +1,5 @@
 
-from CRABClient.UserUtilities import config, getUsernameFromSiteDB
+from CRABClient.UserUtilities import config
 config = config()
 
 config.section_('General')


### PR DESCRIPTION
porting from 2016