### PR TITLE
fix inputDBS in crab config template

### DIFF
--- a/DiMuons/crab/templates/crab_config.py
+++ b/DiMuons/crab/templates/crab_config.py
@@ -14,7 +14,7 @@ config.JobType.outputFiles = ['tuple.root'] ## Must be the same as the output fi
 config.JobType.pluginName = 'Analysis'
 
 config.section_('Data')
-config.Data.inputDBS = 'global'
+config.Data.inputDBS = 'DBS'
 
 config.Data.inputDataset = 'STR'
 # config.Data.lumiMask = 'STR'


### PR DESCRIPTION
Simple fix. 
In crab template use 'DBS' instead of 'global' as default to inputDBS.